### PR TITLE
Externalize `Animated` state

### DIFF
--- a/src/Animation/Animated.luau
+++ b/src/Animation/Animated.luau
@@ -20,7 +20,7 @@ type Self<V> = Types.Animated<V> & {
 	_activeGenerator: Types.CurveGenerator<V>,
 	_activeCurve: Types.AnimationCurve<V>,
 
-	_activeState: { any },
+	_activeDynamics: { any },
 
 	_shouldRegenerate: boolean?,
 
@@ -28,16 +28,16 @@ type Self<V> = Types.Animated<V> & {
 }
 
 local function _syncFromCurve<V>(
-	inPlaceState: { any },
+	dynamics: { any },
 	shouldSleep: boolean,
 	outputValue: V,
 	...: any
 ): (boolean, V)
 	-- clear and update state in place, instead of constructing a new table
-	table.clear(inPlaceState)
+	table.clear(dynamics)
 
 	for i = 1, select("#", ...) do
-		inPlaceState[i] = select(i, ...)
+		dynamics[i] = select(i, ...)
 	end
 
 	return shouldSleep, outputValue
@@ -48,14 +48,14 @@ local class = table.freeze {
 	kind = "state",
 	timeliness = "eager",
 
-	writeState = function<V>(self: Self<V>, index: number, value: any)
-		self._activeState[index] = value
+	setDynamic = function<V>(self: Self<V>, index: number, value: any)
+		self._activeDynamics[index] = value
 		self._shouldRegenerate = true
 
 		change(self)
 	end,
-	readState = function<V>(self: Self<V>, index: number)
-		return self._activeState[index]
+	getDynamic = function<V>(self: Self<V>, index: number)
+		return self._activeDynamics[index]
 	end,
 	_evaluate = function<V>(self: Self<V>)
 		local goal = self._goal
@@ -90,7 +90,7 @@ local class = table.freeze {
 			self._activeCurve = nextGenerator(
 				self._activeStart,
 				self._activeGoal,
-				unpack(self._activeState)
+				unpack(self._activeDynamics)
 			)
 
 			timer:reset()
@@ -105,7 +105,7 @@ local class = table.freeze {
 
 		local oldValue = self._internalValue :: any
 		local shouldSleep, newValue =
-			_syncFromCurve(self._activeState, self._activeCurve(elapsed))
+			_syncFromCurve(self._activeDynamics, self._activeCurve(elapsed))
 
 		self._internalValue = newValue
 
@@ -141,7 +141,7 @@ local function Animated<V>(
 		_activeGenerator = nil,
 		_activeCurve = nil,
 
-		_activeState = {},
+		_activeDynamics = {},
 
 		_timer = timer,
 	}, METATABLE) :: any

--- a/src/Animation/Animated.luau
+++ b/src/Animation/Animated.luau
@@ -27,8 +27,20 @@ type Self<V> = Types.Animated<V> & {
 	_timer: Types.Timer,
 }
 
-local function _unwrap<V>(shouldSleep: boolean, output: V, ...): (boolean, V, { any })
-	return shouldSleep, output, table.pack(...)
+local function _syncFromCurve<V>(
+	inPlaceState: { any },
+	shouldSleep: boolean,
+	outputValue: V,
+	...: any
+): (boolean, V)
+	-- clear and update state in place, instead of constructing a new table
+	table.clear(inPlaceState)
+
+	for i = 1, select("#", ...) do
+		inPlaceState[i] = select(i, ...)
+	end
+
+	return shouldSleep, outputValue
 end
 
 local class = table.freeze {
@@ -78,7 +90,7 @@ local class = table.freeze {
 			self._activeCurve = nextGenerator(
 				self._activeStart,
 				self._activeGoal,
-				table.unpack(self._activeState)
+				unpack(self._activeState)
 			)
 
 			timer:reset()
@@ -92,9 +104,9 @@ local class = table.freeze {
 		end
 
 		local oldValue = self._internalValue :: any
-		local shouldSleep, newValue, newState = _unwrap(self._activeCurve(elapsed))
+		local shouldSleep, newValue =
+			_syncFromCurve(self._activeState, self._activeCurve(elapsed))
 
-		self._activeState = newState
 		self._internalValue = newValue
 
 		-- sleep

--- a/src/Animation/Animated.luau
+++ b/src/Animation/Animated.luau
@@ -4,6 +4,7 @@ local Types = require "../Types"
 
 local Timer = require "./Timer"
 
+local change = require "../Graph/change"
 local depend = require "../Graph/depend"
 local evaluate = require "../Graph/evaluate"
 
@@ -19,21 +20,33 @@ type Self<V> = Types.Animated<V> & {
 	_activeGenerator: Types.CurveGenerator<V>,
 	_activeCurve: Types.AnimationCurve<V>,
 
+	_activeState: { any },
+
+	_shouldRegenerate: boolean?,
+
 	_timer: Types.Timer,
 }
+
+local function _unwrap<V>(shouldSleep: boolean, output: V, ...): (boolean, V, { any })
+	return shouldSleep, output, table.pack(...)
+end
 
 local class = table.freeze {
 	type = "Animated",
 	kind = "state",
 	timeliness = "eager",
 
+	writeState = function<V>(self: Self<V>, index: number, value: any)
+		self._activeState[index] = value
+		self._shouldRegenerate = true
+
+		change(self)
+	end,
+	readState = function<V>(self: Self<V>, index: number)
+		return self._activeState[index]
+	end,
 	_evaluate = function<V>(self: Self<V>)
 		local goal = self._goal
-
-		if not castToState(self._goal) then
-			return false
-		end
-
 		local generator = self._generator
 		local timer = self._timer
 
@@ -44,19 +57,29 @@ local class = table.freeze {
 			depend(self, generator :: any)
 		end
 
+		if castToState(goal) then
+			depend(self, goal)
+		end
+
 		depend(self, timer)
-		depend(self, goal)
 
 		-- wake
 		if
 			nextGoal ~= self._activeGoal :: any
 			or nextGenerator ~= self._activeGenerator
+			or self._shouldRegenerate == true
 		then
+			self._shouldRegenerate = nil
+
 			self._activeStart = self._internalValue
 			self._activeGoal = nextGoal
 
 			self._activeGenerator = nextGenerator
-			self._activeCurve = nextGenerator(self._activeStart, self._activeGoal)
+			self._activeCurve = nextGenerator(
+				self._activeStart,
+				self._activeGoal,
+				table.unpack(self._activeState)
+			)
 
 			timer:reset()
 			timer:unpause()
@@ -68,16 +91,16 @@ local class = table.freeze {
 			elapsed = External.getDeltaTime()
 		end
 
-		local shouldSleep, newValue = self._activeCurve(elapsed)
-		-- sleep
+		local oldValue = self._internalValue :: any
+		local shouldSleep, newValue, newState = _unwrap(self._activeCurve(elapsed))
 
-		if shouldSleep or (self._activeStart :: any) == nextGoal then
+		self._activeState = newState
+		self._internalValue = newValue
+
+		-- sleep
+		if shouldSleep then
 			timer:pause()
 		end
-
-		local oldValue = self._internalValue :: any
-
-		self._internalValue = newValue
 
 		return (oldValue :: any) ~= (newValue :: any)
 	end,
@@ -105,6 +128,8 @@ local function Animated<V>(
 		_generator = mover,
 		_activeGenerator = nil,
 		_activeCurve = nil,
+
+		_activeState = {},
 
 		_timer = timer,
 	}, METATABLE) :: any

--- a/src/Animation/Spring.luau
+++ b/src/Animation/Spring.luau
@@ -11,37 +11,32 @@ local EPSILON = 0.0001
 
 local function springMover(speed: Types.UsedAs<number>, damping: Types.UsedAs<number>)
 	local startP = {}
-	local startV = {}
 
 	local currentP = {}
 	local currentV = {}
 
-	local targetP = {}
-	local numSprings = 0
-
 	local activeType = ""
 
-	return function(start: unknown, target: unknown)
+	return function<V>(start: V, target: V, initialVelocity: { number }?)
 		local discontinuous = typeof(target) ~= activeType
 
-		targetP = unpackType(target)
-		numSprings = #targetP
+		activeType = typeof(target)
+
+		local targetP = unpackType(target)
+		local numSprings = #targetP
 
 		if discontinuous then
 			startP = table.clone(targetP)
 			currentP = table.clone(targetP)
 
-			startV = table.create(numSprings, 0)
+			initialVelocity = table.create(numSprings, 0)
 			currentV = table.create(numSprings, 0)
 		else
 			startP = table.clone(currentP)
-			startV = table.clone(currentV)
 		end
 
-		activeType = typeof(target)
-
 		-- spring stepper
-		return function(elapsed: number)
+		return function(elapsed: number): V
 			local shouldSleep = false
 			local newValue
 
@@ -57,7 +52,7 @@ local function springMover(speed: Types.UsedAs<number>, damping: Types.UsedAs<nu
 					local startP = startP[index] :: number
 					local targetP = targetP[index] :: number
 
-					local startV = startV[index] :: number
+					local startV = initialVelocity[index] :: number
 					local startD = startP - targetP
 
 					local latestD = startD * posPos + startV * posVel
@@ -83,7 +78,7 @@ local function springMover(speed: Types.UsedAs<number>, damping: Types.UsedAs<nu
 				newValue = packType(activeType, currentP)
 			end
 
-			return shouldSleep, newValue
+			return shouldSleep, newValue, currentV
 		end
 	end
 end

--- a/src/Animation/Tween.luau
+++ b/src/Animation/Tween.luau
@@ -8,12 +8,12 @@ local lerp = require "./lerp"
 local peek = require "../State/peek"
 
 local function tweenMover(info: Types.UsedAs<TweenInfo>)
-	return function(start: unknown, target: unknown)
+	return function<V>(start: V, target: V)
 		local activeInfo = peek(info)
 		local duration = getTweenDuration(activeInfo)
 
 		-- tween stepper
-		return function(elapsed: number)
+		return function(elapsed: number): V
 			local alpha = getTweenAlpha(activeInfo, elapsed)
 
 			return elapsed >= duration, lerp(start, target, alpha)

--- a/src/Animation/packType.luau
+++ b/src/Animation/packType.luau
@@ -34,7 +34,7 @@ local PACK_METHODS = {
 	end,
 }
 
-local function packType(dataType: string, packed: { number })
+local function packType(dataType: string, packed: { number }): any
 	local packer = PACK_METHODS[dataType]
 
 	if type(packer) == "function" then

--- a/src/Animation/unpackType.luau
+++ b/src/Animation/unpackType.luau
@@ -29,7 +29,7 @@ local UNPACK_METHODS = {
 	end,
 }
 
-local function unpackType(value: any)
+local function unpackType(value: any): { number }
 	local typeString = typeof(value)
 	local unpacker = UNPACK_METHODS[typeString]
 

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -13,6 +13,16 @@ export type Child = Instance | ((Instance) -> Instance?) | { Child } | StateObje
 export type Validity = "busy" | "invalid" | "valid"
 export type Timeliness = "lazy" | "eager"
 
+export type PackableType =
+	"number"
+	| "Vector2"
+	| "Vector3"
+	| "UDim"
+	| "UDim2"
+	| "CFrame"
+	| "Color3"
+	| string
+
 export type Properties = { [SpecialKey<string> | string]: any }
 
 export type Scope<T = any> = { CleanupTask } & T
@@ -215,8 +225,8 @@ export type ConFusion = {
 
 	-- Utility
 	read Contextual: ContextualConstructor,
-	read peek: <V>(value: UsedAs<V> | V) -> V,
 	read map: <V, O>(value: StateObject<V>, callback: (V) -> O) -> Computed<O>,
+	read peek: <V>(value: UsedAs<V> | V) -> V,
 	read flatten: <T>(use: Use, target: UsedAs<T>) -> T,
 
 	-- Graph
@@ -237,6 +247,8 @@ export type ConFusion = {
 	read Animated: AnimatedConstructor,
 	read Tween: TweenConstructor,
 	read Spring: SpringConstructor,
+	read packType: (dataType: PackableType, input: { number }) -> any?,
+	read unpackType: (input: any) -> { number },
 
 	-- Instances
 	read New: (

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -141,8 +141,8 @@ export type CurveGenerator<V> = (start: V, goal: V, ...any) -> AnimationCurve<V>
 export type Animated<V> = {
 	type: "Animated",
 
-	writeState: (Animated<V>, index: number, value: any) -> (),
-	readState: (Animated<V>, index: number) -> any?,
+	setDynamic: (Animated<V>, index: number, value: any) -> (),
+	getDynamic: (Animated<V>, index: number) -> any?,
 } & StateObject<V>
 
 type AnimatedConstructor = <V>(

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -134,12 +134,15 @@ export type Timer = StateObject<number> & {
 	reset: (Timer) -> (),
 }
 
-export type AnimationCurve<V> = (elapsed: number) -> (boolean, V)
-export type CurveGenerator<V> = (start: V, goal: V) -> AnimationCurve<V>
+export type AnimationCurve<V> = (elapsed: number) -> (boolean, V, ...any)
+export type CurveGenerator<V> = (start: V, goal: V, ...any) -> AnimationCurve<V>
 
 -- A state object whose value can be animated with a AnimatedMover callback.
 export type Animated<V> = {
 	type: "Animated",
+
+	writeState: (Animated<V>, index: number, value: any) -> (),
+	readState: (Animated<V>, index: number) -> any?,
 } & StateObject<V>
 
 type AnimatedConstructor = <V>(

--- a/src/init.luau
+++ b/src/init.luau
@@ -58,19 +58,21 @@ local Fusion = table.freeze {
 
 	-- Utility
 	Contextual = require "@self/Utility/Contextual",
-	peek = require "@self/State/peek",
 	map = require "@self/Utility/map",
+	peek = require "@self/State/peek",
 	flatten = require "@self/Utility/flatten",
-
+	
 	-- Graph
 	Observer = require "@self/Graph/Observer",
-
+	
 	-- Animation
 	Timer = require "@self/Animation/Timer",
 	Animated = require "@self/Animation/Animated",
 	Tween = require "@self/Animation/Tween",
 	Spring = require "@self/Animation/Spring",
-
+	packType = require "@self/Animation/packType",
+	unpackType = require "@self/Animation/unpackType",
+	
 	-- Instances
 	New = require "@self/Instances/New",
 	Hydrate = require "@self/Instances/Hydrate",


### PR DESCRIPTION
Reworks `Animated`s to have the option to "externalize" their state, making it so you can modify them using methods like `:setState` and `:getState`.

I mostly thought of this because with the current implementation of `Animated`s, there is no way to set the velocity of a spring externally.