### PR TITLE
Dissolve constant state objects

### DIFF
--- a/src/calc/Computed.luau
+++ b/src/calc/Computed.luau
@@ -8,19 +8,37 @@ local depend = require "../graph/depend"
 local castToState = require "./castToState"
 local isSimilar = require "./isSimilar"
 
+local dissolvingUse = require "../use/dissolvingUse"
 local peek = require "../use/peek"
 
 local deriveScope = require "../memory/deriveScope"
 local destructor = require "../memory/destructor"
 local doCleanup = require "../memory/doCleanup"
+local innerScope = require "../memory/innerScope"
 
 local parseError = require "../logging/parseError"
 
-
+type ComputedProcessor<S, T> = (use: calc.Use, scope: memory.Scope<S>) -> T
 type Self<T, S> = calc.Computed<T> & {
 	_innerScope: memory.Scope<S>?,
-	_processor: (use: calc.Use, scope: memory.Scope<S>) -> T,
+	_processor: ComputedProcessor<S, T>,
 }
+
+local function checkDissolvable<T, S>(
+	scope: memory.Scope<S>,
+	processor: ComputedProcessor<S, T>
+): (boolean, T?)
+	local dissolvingScope = innerScope(scope)
+	local success, value = pcall(processor, dissolvingUse, dissolvingScope)
+
+	if success then
+		return true, value
+	end
+
+	doCleanup(dissolvingScope)
+
+	return false
+end
 
 local class = table.freeze {
 	type = "Computed",
@@ -71,8 +89,14 @@ local METATABLE = table.freeze { __index = class }
 
 local function Computed<T, S>(
 	scope: memory.Scope<S>,
-	processor: (calc.Use, memory.Scope<S>) -> T
+	processor: ComputedProcessor<S, T>
 ): calc.Computed<T>
+	local canDissolve, constant = checkDissolvable(scope, processor)
+
+	if canDissolve then
+		return constant
+	end
+
 	local newComputed: Self<T, S> = setmetatable({
 		scope = scope,
 		createdAt = os.clock(),

--- a/src/calc/For/checkDissolvable.luau
+++ b/src/calc/For/checkDissolvable.luau
@@ -1,0 +1,54 @@
+--!strict
+local calc = require "../types"
+local memory = require "../../memory/types"
+
+local External = require "../../External"
+
+local castToState = require "../castToState"
+
+local doCleanup = require "../../memory/doCleanup"
+local innerScope = require "../../memory/innerScope"
+
+local dissolvingUse = require "../../use/dissolvingUse"
+
+local function checkDissolvable<S, IK, IV, OK, OV>(
+	scope: memory.Scope<S>,
+	input: calc.UsedAs<{ [IK]: IV }>,
+	processor: (
+		calc.Use,
+		memory.Scope<S>,
+		IK,
+		IV
+	) -> (OK?, OV?)
+): (boolean, { [OK]: OV }?)
+	if castToState(input) then
+		return false, nil
+	end
+
+	local dissolvingScope = innerScope(scope)
+	local output = {}
+
+	for key, value in input do
+		local ok, outputKey, outputValue =
+			pcall(processor, dissolvingUse, dissolvingScope, key, value)
+
+		if not ok then
+			doCleanup(dissolvingScope)
+
+			return false, nil
+		end
+
+		if outputKey == nil or outputValue == nil then
+			continue
+		elseif output[outputKey] ~= nil then
+			External.logErrorNonFatal("forKeyCollision", nil, tostring(outputKey))
+			continue
+		end
+
+		output[outputKey] = outputValue
+	end
+
+	return true, output
+end
+
+return checkDissolvable

--- a/src/calc/ForKeys.luau
+++ b/src/calc/ForKeys.luau
@@ -8,9 +8,10 @@ local External = require "../External"
 local doCleanup = require "../memory/doCleanup"
 
 local Computed = require "./Computed"
+local For = require "./For"
 local Value = require "./Value"
 
-local For = require "./For"
+local checkDissolvable = require "./For/checkDissolvable"
 
 local parseError = require "../logging/parseError"
 
@@ -67,7 +68,13 @@ local function ForKeys<S, IK, IV, OK>(
 	scope: memory.Scope<S>,
 	inputTable: calc.UsedAs<{ [IK]: IV }>,
 	processor: (calc.Use, memory.Scope<S>, IK) -> OK
-): calc.For<OK, IV>
+): calc.For<OK, IV> | { [OK]: IV }
+	local canDissolve, constant = checkDissolvable(scope, inputTable, processor)
+
+	if canDissolve then
+		return constant
+	end
+
 	return For(scope, inputTable, function(scope, initialKey, initialValue)
 		return SubObject(scope, initialKey, initialValue, processor)
 	end)

--- a/src/calc/ForPairs.luau
+++ b/src/calc/ForPairs.luau
@@ -8,9 +8,10 @@ local External = require "../External"
 local doCleanup = require "../memory/doCleanup"
 
 local Computed = require "./Computed"
+local For = require "./For"
 local Value = require "./Value"
 
-local For = require "./For"
+local checkDissolvable = require "./For/checkDissolvable"
 
 local parseError = require "../logging/parseError"
 
@@ -82,7 +83,13 @@ local function ForPairs<S, IK, IV, OK, OV>(
 		IK,
 		IV
 	) -> (OK, OV)
-): calc.For<OK, OV>
+): calc.For<OK, OV> | { [OK]: OV }
+	local canDissolve, constant = checkDissolvable(scope, inputTable, processor)
+
+	if canDissolve then
+		return constant
+	end
+
 	return For(scope, inputTable, function(scope, initialKey, initialValue)
 		return SubObject(scope, initialKey, initialValue, processor)
 	end)

--- a/src/calc/ForValues.luau
+++ b/src/calc/ForValues.luau
@@ -11,6 +11,8 @@ local Computed = require "./Computed"
 local For = require "./For"
 local Value = require "./Value"
 
+local checkDissolvable = require "./For/checkDissolvable"
+
 local parseError = require "../logging/parseError"
 
 local SUB_OBJECT_META = table.freeze {
@@ -66,7 +68,21 @@ local function ForValues<S, IK, IV, OV>(
 	scope: memory.Scope<S>,
 	inputTable: calc.UsedAs<{ [IK]: IV }>,
 	processor: (calc.Use, memory.Scope<S>, IV) -> OV
-): calc.For<IK, OV>
+): calc.For<IK, OV> | { [IK]: OV }
+	local canDissolve, constant = checkDissolvable(
+		scope,
+		inputTable,
+		function(use, scope, inputKey, inputValue)
+			local newValue = processor(use, scope, inputValue)
+
+			return inputKey, newValue
+		end
+	)
+
+	if canDissolve then
+		return constant
+	end
+
 	return For(scope, inputTable, function(scope, initialKey, initialValue)
 		return SubObject(scope, initialKey, initialValue, processor)
 	end)

--- a/src/calc/types.luau
+++ b/src/calc/types.luau
@@ -35,7 +35,7 @@ export type Computed<T> = {
 export type ComputedConstructor = <S, T>(
 	scope: memory.Scope<S>,
 	processor: (Use, memory.Scope<S>) -> T
-) -> Computed<T>
+) -> Computed<T> | T
 
 -- A state object which maps over keys and/or values in another table.
 export type For<OK, OV> = {
@@ -46,16 +46,16 @@ export type ForPairsConstructor = <S, IK, IV, OK, OV>(
 	scope: memory.Scope<S>,
 	inputTable: UsedAs<{ [IK]: IV }>,
 	processor: (Use, memory.Scope<S>, IK, IV) -> (OK, OV)
-) -> For<OK, OV>
+) -> For<OK, OV> | { [OK]: OV }
 export type ForKeysConstructor = <S, IK, IV, OK>(
 	scope: memory.Scope<S>,
 	inputTable: UsedAs<{ [IK]: IV }>,
 	processor: (Use, memory.Scope<S>, IK) -> OK
-) -> For<OK, IV>
+) -> For<OK, IV> | { [OK]: IV }
 export type ForValuesConstructor = <S, IK, IV, OV>(
 	scope: memory.Scope<S>,
 	inputTable: UsedAs<{ [IK]: IV }>,
 	processor: (Use, memory.Scope<S>, IV) -> OV
-) -> For<IK, OV>
+) -> For<IK, OV> | { [IK]: OV }
 
 return nil

--- a/src/use/dissolvingUse.luau
+++ b/src/use/dissolvingUse.luau
@@ -1,0 +1,13 @@
+local calc = require "../calc/types"
+
+local castToState = require "../calc/castToState"
+
+local function dissolvingUse<T>(target: calc.UsedAs<T>): T
+	if castToState(target) then
+		error "not-dissolvable"
+	end
+
+	return target
+end
+
+return dissolvingUse


### PR DESCRIPTION
#4 (for new package structure)

TL;DR reduces memory usage by "dissolving" state objects into their computed values if they aren't dealing with any state.