### PR TITLE
Protect Animateds from breaking when passed `NaN`/`inf`

### DIFF
--- a/src/logging/messages.luau
+++ b/src/logging/messages.luau
@@ -4,6 +4,9 @@ return {
 
 	destroyedTwice = "`doCleanup()` was given something that it is already cleaning up. Unclear how to proceed.",
 
+	animatedInvalidGoal = "An Animated was given a '%s' goal. Ensure '%s' isn't being passed anywhere!",
+	animatedInvalidMotion = "An Animated encountered '%s' during motion. Ensure '%s' isn't being passed anywhere!",
+
 	missingChild = "Could not find child '%s' in '%s'.",
 	missingChildClass = "Could not find child of class '%s' in '%s'.",
 	missingDescendant = "Could not find descendant '%s' in '%s'.",

--- a/src/motion/Animated.luau
+++ b/src/motion/Animated.luau
@@ -69,14 +69,26 @@ local class = table.freeze {
 		local timer = self._timer
 
 		local nextGoal = peek(goal)
+
+		if castToState(goal) then
+			depend(self, goal)
+		end
+
+		-- protect against NaN goals
+		if nextGoal ~= nextGoal then
+			External.logWarn(
+				"animatedInvalidGoal",
+				tostring(nextGoal),
+				tostring(nextGoal)
+			) -- this looks a little ridiculous...
+
+			return false
+		end
+
 		local nextGenerator = peek(generator) :: motion.CurveGenerator<V>
 
 		if castToState(generator) then
 			depend(self, generator :: any)
-		end
-
-		if castToState(goal) then
-			depend(self, goal)
 		end
 
 		depend(self, timer)
@@ -112,6 +124,16 @@ local class = table.freeze {
 		local oldValue = self._internalValue :: any
 		local shouldSleep, newValue =
 			_syncFromCurve(self._activeDynamics, self._activeCurve(elapsed))
+
+		if (newValue :: any) ~= (newValue :: any) then
+			External.logWarn(
+				"animatedInvalidMotion",
+				tostring(nextGoal),
+				tostring(nextGoal)
+			)
+
+			newValue = self._activeGoal
+		end
 
 		self._internalValue = newValue
 

--- a/src/motion/Spring.luau
+++ b/src/motion/Spring.luau
@@ -58,16 +58,20 @@ local function springMover(speed: calc.UsedAs<number>, damping: calc.UsedAs<numb
 					local startD = startP - targetP
 
 					local latestD = startD * posPos + startV * posVel
-					local newV = startD * velPos + startV * velVel
+					local latestV = startD * velPos + startV * velVel
 
-					if math.abs(latestD) > EPSILON or math.abs(newV) > EPSILON then
+					if latestD ~= latestD or latestV ~= latestV then
+						latestD, latestV = 0, 0
+					end
+
+					if math.abs(latestD) > EPSILON or math.abs(latestV) > EPSILON then
 						isMoving = true
 					end
 
-					local newP = latestD + targetP
+					local latestP = latestD + targetP
 
-					currentP[index] = newP
-					currentV[index] = newV
+					currentP[index] = latestP
+					currentV[index] = latestV
 				end
 
 				if not isMoving then


### PR DESCRIPTION
Currently passing `NaN` or `inf` into Animateds can cause them to behave weirdly or sometimes just makes them completely unusable.