### PR TITLE
Consolidate object destructors into one function in the scope

### DIFF
--- a/src/memory/destructor.luau
+++ b/src/memory/destructor.luau
@@ -1,39 +1,38 @@
 --!strict
 local graph = require "../graph/types"
 
-local nameOf = require "../logging/nameOf"
 local nicknames = require "../logging/nicknames"
 
-local function destroy<V>(target: graph.GraphObject)
+local function destroy(target: graph.GraphObject)
 	target.scope = nil
 
 	local using = target._using
 
-	if using then
-		for dependency in using do
-			dependency._users[target] = nil
-			using[dependency] = nil
-		end
+	for dependency in using do
+		dependency._users[target] = nil
+		using[dependency] = nil
 	end
 
 	local users = target._users
 
-	if users then
-		for user in users do
-			user._using[target] = nil
-			users[user] = nil
-		end
+	for user in users do
+		user._using[target] = nil
+		users[user] = nil
 	end
 end
 
-local function destructor(target: graph.GraphObject)
+local function destructor<T>(target: graph.GraphObject & T, auxiliary: (T) -> ()?)
 	local function destruct()
 		destroy(target)
+
+		if auxiliary then
+			auxiliary(target)
+		end
 
 		nicknames[destruct] = nil
 	end
 
-	nicknames[destruct] = nameOf(target, "unknown") .. "-destructor"
+	nicknames[destruct] = debug.info(2, "n") or "unknown"
 
 	return destruct
 end


### PR DESCRIPTION
Excuse the long title, I'm not sure how to adequately describe this in a terse fashion.

Currently whenever a state object that has an "auxiliary" destructor, like Computeds, is created, a new function that handles the auxiliary destruction logic is created for that specific state object, which obvious takes up more memory.

What this PR does is make the auxiliary destruction logic reusable for each state object, instead of creating a new one for each state object.

For example instead of something like this;
```luau
local newComputed = setmetatable(...)

table.insert(scope, {
    destructor(newComputed),
    function()
        -- auxiliary destruction logic (i.e. cleaning up innerScope)
        -- this won't be optimized since we're using the 'newComputed' upvalue!
    end
})
```
You'd have a separate `auxiliaryDestructor` function you could define and pass into the `destructor` utility function, which would call the `auxiliaryDestructor` function on the passed graph object. No more defining a new unique function for each state object!
```luau
local function auxiliaryDestructor(computed)
    -- auxiliary destruction logic (i.e. cleaning up innerScope, but on the passed computed)
end

-- ...

table.insert(scope, destructor(newComputed, auxiliaryDestructor))
```

`destructor` would return a single new unique function for handling both generic destructor logic, and the auxiliary destructor logic, instead of creating a new function for each auxiliary destructor...

Again sorry if this doesn't make much sense, I'm not that great at explaining these things.