### PR TITLE
Error yielding states processors

### DIFF
--- a/src/calc/doesYield.luau
+++ b/src/calc/doesYield.luau
@@ -1,0 +1,23 @@
+local function yieldingHandler<R...>(
+	thread: thread,
+	ok: boolean,
+	...: R...
+): (boolean, thread, R...)
+	if ok == false then
+		error(debug.traceback(thread, ...), 3)
+	end
+
+	if coroutine.status(thread) == "suspended" then
+		return true, thread
+	end
+
+	return false, thread, ...
+end
+
+local function doesYield<A..., R...>(callback: (A...) -> R..., ...: A...): (boolean, thread, R...)
+	local thread = coroutine.create(callback)
+
+	return yieldingHandler(thread, coroutine.resume(thread, ...))
+end
+
+return doesYield

--- a/src/calc/noYield.luau
+++ b/src/calc/noYield.luau
@@ -1,7 +1,5 @@
 local doesYield = require "./doesYield"
 
-local parseError = require "../logging/parseError"
-
 local function yieldHandler<R...>(execOk: boolean, ...: R...): (boolean, boolean, R...)
 	if not execOk then
 		return false, false, ...
@@ -18,8 +16,12 @@ local function yieldHandler<R...>(execOk: boolean, ...: R...): (boolean, boolean
 	return true, false, select(3, ...)
 end
 
-local function noYield<A..., R...>(callback: (A...) -> R..., ...: A...): (boolean, boolean, R...)
-	return yieldHandler(xpcall(doesYield, parseError, callback, ...))
+local function noYield<A..., R1..., R2...>(
+	callback: (A...) -> R1...,
+	errHandler: (string) -> R2...,
+	...: A...
+): (boolean, boolean, R1...)
+	return yieldHandler(xpcall(doesYield, errHandler, callback, ...))
 end
 
 return noYield

--- a/src/calc/noYield.luau
+++ b/src/calc/noYield.luau
@@ -1,0 +1,25 @@
+local doesYield = require "./doesYield"
+
+local parseError = require "../logging/parseError"
+
+local function yieldHandler<R...>(execOk: boolean, ...: R...): (boolean, boolean, R...)
+	if not execOk then
+		return false, false, ...
+	end
+
+	local yields: boolean, thread: thread = ...
+
+	if yields then
+		coroutine.close(thread)
+
+		return true, true
+	end
+
+	return true, false, select(3, ...)
+end
+
+local function noYield<A..., R...>(callback: (A...) -> R..., ...: A...): (boolean, boolean, R...)
+	return yieldHandler(xpcall(doesYield, parseError, callback, ...))
+end
+
+return noYield


### PR DESCRIPTION
Implements https://github.com/dphfox/Fusion/issues/15

I'm still not entirely sure about this change, it doesn't exactly seem necessary and if anything seems like it'd be quite annoying. I'm open to allowing Computeds to be asynchronous, but more work still needs to be done for that to actually be a feature.

For now it might be beneficial to warn against yielding processors in Computeds/For as it can cause some weird issues with the graph not being consistently up to date.