### PR TITLE
Readd `Ref` SpecialKey

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -183,6 +183,7 @@ local ConFusion = table.freeze {
 	OnStartup = require "@self/roblox-instances/keys/OnStartup",
 	OnRemoval = require "@self/roblox-instances/keys/OnRemoval",
 	Passthrough = require "@self/roblox-instances/keys/Passthrough",
+	Ref = require "@self/roblox-instances/keys/Ref",
 	Attribute = require "@self/roblox-instances/keys/Attribute",
 	AttributeChange = require "@self/roblox-instances/keys/AttributeChange",
 	AttributeOut = require "@self/roblox-instances/keys/AttributeOut",

--- a/src/init.luau
+++ b/src/init.luau
@@ -107,6 +107,7 @@ type ConFusion = {
 	read OnStartup: instances.SpecialKey<"OnStartup">,
 	read OnRemoval: instances.SpecialKey<"OnRemoval">,
 	read Passthrough: instances.SpecialKey<"Passthrough">,
+	read Ref: instances.SpecialKey<"Ref">,
 	read Attribute: (attribute: string) -> instances.SpecialKey<"Attribute">,
 	read AttributeChange: (attribute: string) -> instances.SpecialKey<"AttributeChange">,
 	read AttributeOut: (attribute: string) -> instances.SpecialKey<"AttributeOut">,

--- a/src/roblox-instances/keys/Ref.luau
+++ b/src/roblox-instances/keys/Ref.luau
@@ -1,0 +1,21 @@
+local calc = require "../../calc/types"
+
+local External = require "../../External"
+local xtypeof = require "../../xtypeof"
+
+local SpecialKey = require "./SpecialKey"
+
+local Ref = SpecialKey "Ref" {
+	stage = "self",
+	apply = function(_, applyTo: Instance, refs: { calc.Value<Instance> })
+		for _, ref in refs do
+			if xtypeof(ref) ~= "Value" then
+				External.logError("expectedType", nil, "Value", xtypeof(ref))
+			end
+
+			ref:set(applyTo)
+		end
+	end,
+}
+
+return Ref


### PR DESCRIPTION
Reverts #24 

As it turns out, the `Ref` SpecialKey is actually pretty useful. It's way easier to do something like this:

```luau
local Ref, Children = ConFusion.Ref, ConFusion.Children

local function Textbox(
	scope: ConFusion.Scope,
	props: { text: string, ref: ConFusion.Value<TextBox>? }
)
	return scope:New "Frame" {
		[Children] = scope:New "TextBox" {
			Text = props.text,

			[Ref] = { props.ref },
		},
	}
end
```
than this:
```luau
local Children = ConFusion.Children

local function Textbox(
	scope: ConFusion.Scope,
	props: { text: string, ref: ConFusion.Value<TextBox>? }
)
	local field = scope:New "TextBox" {
		Text = props.text,
	}

	if props.ref then
		props.ref:set(field)
	end

	return scope:New "Frame" {
		[Children] = field,
	}
end
```
This doesn't even go into how you would do this with multiple refs, but it'd probably be even more convoluted.

I think bringing back the `Ref` SpecialKey is a good idea, it's a useful utility that makes using Values as refs quick and painless. The `Value:set` functionality should and will remain, as it does have niche usecases where it may be valuable to allow for chaining like that.