### PR TITLE
Replace "immediate" argument of `observe` with `observeImmediate`

### DIFF
--- a/src/core-graph/observe.luau
+++ b/src/core-graph/observe.luau
@@ -1,7 +1,6 @@
 local graph = require "./types"
 local memory = require "../core-memory/types"
 
-local External = require "../core-external/External"
 local castToGraph = require "./castToGraph"
 local evaluate = require "./evaluate"
 local nameOf = require "../core-logging/nameOf"
@@ -10,13 +9,8 @@ local nicknames = require "../core-logging/nicknames"
 local function observe(
 	scope: memory.Scope,
 	subject: graph.GraphObject,
-	callback: () -> (),
-	immediate: boolean?
+	callback: () -> ()
 ): () -> ()
-	if immediate then
-		External.doTaskImmediate(callback)
-	end
-
 	if castToGraph(subject) == nil then
 		return
 	end

--- a/src/core-graph/observeImmediate.luau
+++ b/src/core-graph/observeImmediate.luau
@@ -1,0 +1,17 @@
+local graph = require "./types"
+local memory = require "../core-memory/types"
+
+local External = require "../core-external/External"
+local observe = require "./observe"
+
+local function observeImmediate(
+	scope: memory.Scope,
+	subject: graph.GraphObject,
+	callback: () -> ()
+): () -> ()
+	External.doTaskImmediate(callback)
+
+	return observe(scope, subject, callback)
+end
+
+return observeImmediate

--- a/src/core-graph/types.luau
+++ b/src/core-graph/types.luau
@@ -25,8 +25,7 @@ export type GraphObject = {
 export type Observe = (
 	scope: memory.Scope,
 	subject: GraphObject,
-	callback: () -> (),
-	immediate: boolean?
+	callback: () -> ()
 ) -> () -> ()
 
 return {

--- a/src/init.luau
+++ b/src/init.luau
@@ -76,6 +76,7 @@ type ConFusion = {
 
 	-- Core: Graph
 	read observe: graph.Observe,
+	read observeImmediate: graph.Observe,
 
 	-- Core: Use
 	read peek: calc.Use,
@@ -170,6 +171,7 @@ return table.freeze {
 
 	-- Core: Graph
 	observe = require "@self/core-graph/observe",
+	observeImmediate = require "@self/core-graph/observeImmediate",
 
 	-- Core: Use
 	peek = require "@self/core-use/peek",

--- a/src/roblox-instances/applyProperties.luau
+++ b/src/roblox-instances/applyProperties.luau
@@ -4,7 +4,7 @@ local memory = require "../core-memory/types"
 
 local External = require "../core-external/External"
 local Parent = require "./keys/Parent"
-local observe = require "../core-graph/observe"
+local observeImmediate = require "../core-graph/observeImmediate"
 local parseError = require "../core-logging/parseError"
 local peek = require "../core-use/peek"
 local sortKeys = require "./keys/sortKeys"
@@ -59,9 +59,9 @@ local function applyProperty(
 	property: string,
 	value: calc.UsedAs<any>
 )
-	observe(scope, value, function()
+	observeImmediate(scope, value, function()
 		setProperty(instance, property, peek(value))
-	end, true)
+	end)
 end
 
 local function applyProperties(

--- a/src/roblox-instances/keys/Attribute.luau
+++ b/src/roblox-instances/keys/Attribute.luau
@@ -3,7 +3,7 @@ local instances = require "../types"
 local memory = require "../../core-memory/types"
 
 local SpecialKey = require "./SpecialKey"
-local observe = require "../../core-graph/observe"
+local observeImmediate = require "../../core-graph/observeImmediate"
 local peek = require "../../core-use/peek"
 
 local KEY_CACHE = {}
@@ -16,9 +16,9 @@ local function Attribute(attribute: string): instances.SpecialKey<"Attribute">
 			"self",
 			"Attribute",
 			function(scope: memory.Scope, apply_to: Instance, value: calc.UsedAs<any>)
-				observe(scope, value, function()
+				observeImmediate(scope, value, function()
 					apply_to:SetAttribute(attribute, peek(value))
-				end, true)
+				end)
 			end
 		)
 

--- a/src/roblox-instances/keys/Parent.luau
+++ b/src/roblox-instances/keys/Parent.luau
@@ -4,7 +4,7 @@ local memory = require "../../core-memory/types"
 
 local External = require "../../core-external/External"
 local SpecialKey = require "./SpecialKey"
-local observe = require "../../core-graph/observe"
+local observeImmediate = require "../../core-graph/observeImmediate"
 local peek = require "../../core-use/peek"
 
 local function setParent(instance: Instance, parent: Instance?)
@@ -21,8 +21,8 @@ return SpecialKey(
 	"ancestor",
 	"Parent",
 	function(scope: memory.Scope, apply_to: Instance, parent: calc.UsedAs<Instance?>)
-		observe(scope, parent, function()
+		observeImmediate(scope, parent, function()
 			setParent(apply_to, peek(parent))
-		end, true)
+		end)
 	end
 ) :: instances.SpecialKey<"Parent">

--- a/src/roblox-instances/keys/Tag.luau
+++ b/src/roblox-instances/keys/Tag.luau
@@ -3,7 +3,7 @@ local instances = require "../types"
 local memory = require "../../core-memory/types"
 
 local SpecialKey = require "./SpecialKey"
-local observe = require "../../core-graph/observe"
+local observeImmediate = require "../../core-graph/observeImmediate"
 local peek = require "../../core-use/peek"
 
 local KEY_CACHE = {}
@@ -20,7 +20,7 @@ local function Tag(tag: string): instances.SpecialKey<"Tag">
 				apply_to: Instance,
 				enabled: calc.UsedAs<boolean>
 			)
-				observe(scope, enabled, function()
+				observeImmediate(scope, enabled, function()
 					local value = peek(enabled)
 
 					if value == true then
@@ -28,7 +28,7 @@ local function Tag(tag: string): instances.SpecialKey<"Tag">
 					elseif apply_to:HasTag(tag) then
 						apply_to:RemoveTag(tag)
 					end
-				end, true)
+				end)
 			end
 		)
 


### PR DESCRIPTION
Replaces the third `immediate` parameter of observe with a different function entirely for clarity.